### PR TITLE
assign subscribers to by2030 group

### DIFF
--- a/index.html
+++ b/index.html
@@ -244,7 +244,12 @@
                         
                         <div class="mbr-subscribe mbr-subscribe-dark input-group">
                             <input type="email" class="form-control" name="EMAIL" required="" data-form-field="Email" placeholder="Enter your email address..." id="mce-EMAIL">
-                            
+                            <ul style="display: none">
+                                <li><input type="checkbox" value="1" name="group[6657][1]" id="mce-group[6657]-6657-0"><label for="mce-group[6657]-6657-0">Qzzr</label></li>
+                                <li><input type="checkbox" value="2" name="group[6657][2]" id="mce-group[6657]-6657-1"><label for="mce-group[6657]-6657-1">Subscribe</label></li>
+                                <li><input type="checkbox" value="8" name="group[6657][8]" id="mce-group[6657]-6657-2"><label for="mce-group[6657]-6657-2">undp.org pop-up capture</label></li>
+                                <li><input type="checkbox" value="32" name="group[6657][32]" id="mce-group[6657]-6657-3" checked><label for="mce-group[6657]-6657-3">by2030</label></li>
+                            </ul>
                             <span class="input-group-btn"><button type="submit" class="btn btn-danger active">JOIN NOW</button></span>
                         </div>
                     </form>


### PR DESCRIPTION
1. Subscribers can be automatically assigned to subgroup by2030 when they are posted in MailChimp.
2. There is a caching time for MailChimp to update the list and global search result.